### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -2,7 +2,7 @@ const wallet = require('eth-lightwallet');
 var superAgent = require('superagent');
 var RequestManager = require('./request');
 const EWT = require('ethereum-web-token');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 const pwDerivedKey = new Uint8Array([215,152,86,175,5,168,43,177,135,97,218,89,136,5,110,93,193,114,94,197,247,212,127,83,200,150,255,124,17,245,91,10]);
 const CHALL_RSP_ABI = [{name: 'cr', type: 'function', inputs: [{type: 'uint256'}]}];

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,4 +1,4 @@
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 const ACCOUNT_URL = 'https://account.cosign.io/v0';
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "eth-lightwallet": "^2.4.3",
     "ethereum-web-token": "^0.1.7",
-    "node-uuid": "^1.4.7",
-    "superagent": "^2.2.0"
+    "superagent": "^2.2.0",
+    "uuid": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.